### PR TITLE
LP migration + new plugin pages + more

### DIFF
--- a/docs/plugins/AdvancedBan.md
+++ b/docs/plugins/AdvancedBan.md
@@ -1,0 +1,54 @@
+---
+id: advancedban
+title: AdvancedBan
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: AdvancedBan
+description: A bans and punishment management system
+keywords:
+  - Spigot
+  - Moderation tools
+  - Punishment
+  - kick
+  - ban
+  - Pterodactyl Panel
+  - Minecraft
+  - Bloom.host
+image: https://bloom.host/assets/images/logo.png
+---
+# AdvancedBan
+
+### What does the plugin do?
+
+Allows your server staff to issue punishments to players who break your server's rules, and can be used as an free alternative to [LiteBans](https://docs.bloom.host/plugins/Litebans).
+
+## Installation
+
+Download the plugin off the [Spigot resource page](https://www.spigotmc.org/resources/advancedban.8695/) and install it in the `plugins` folder.
+For assistance on how to install plugins, please refer to the [plugin installation page](https://docs.bloom.host/plugins).
+
+You will then need to decide if you are going to be using internal storage (HSQLDB) or external storage (MySQL).
+
+If you decide to use MySQL for AdvancedBan, you can [learn how to setup a MySQL database here](https://docs.bloom.host/databases).
+
+## Usage 
+AdvancedBan has many commands to be able to moderate and punish rule-breakers, the most important commands are here:
+
+* `/ban (-s) [player] [REASON[` - permanently bans a player for the reason you specify
+* `/tempban (-s) [player] [Duration] <Reason>` - Temporarily bans a player for the duration and reason you specify
+* `/kick (-s) [player] <reason>` - Kicks a player you specify
+* `/mute (-s) [player] <reason>` - permanently mutes a player for the reason you specify
+* `/tempmute (-s) [player] [Duration] <Reason>` - Temporarily mutes a player for the duration and reason you specify
+* `/warn (-s) [player] <reason>` - Temporarily bans a player for the duration and reason you specify
+* `/tempwarn  (-s) [player] [Duration] <Reason>` - Temporarily warns a player for the duration and reason you specify
+* `/history [player] <page>` - View moderation actions taken against a player 
+
+You can add -s to most of the punishment commands to make their outputs silent - this makes it so that people won't see an announcement when someone gets punished.
+
+There are more commands and features such as pre-prepared punishment layouts and the ability to set notes on players - see the [wiki](https://github.com/DevLeoko/AdvancedBan/wiki) for more information.
+
+## Info
+
+[Spigot Resource Page](https://www.spigotmc.org/resources/advancedban.8695/)
+
+[Github](https://github.com/DevLeoko/AdvancedBan)

--- a/docs/plugins/AdvancedBan.md
+++ b/docs/plugins/AdvancedBan.md
@@ -34,14 +34,16 @@ If you decide to use MySQL for AdvancedBan, you can [learn how to setup a MySQL 
 ## Usage 
 AdvancedBan has many commands to be able to moderate and punish rule-breakers, the most important commands are here:
 
-* `/ban (-s) [player] [REASON[` - permanently bans a player for the reason you specify
-* `/tempban (-s) [player] [Duration] <Reason>` - Temporarily bans a player for the duration and reason you specify
-* `/kick (-s) [player] <reason>` - Kicks a player you specify
-* `/mute (-s) [player] <reason>` - permanently mutes a player for the reason you specify
-* `/tempmute (-s) [player] [Duration] <Reason>` - Temporarily mutes a player for the duration and reason you specify
-* `/warn (-s) [player] <reason>` - Temporarily bans a player for the duration and reason you specify
-* `/tempwarn  (-s) [player] [Duration] <Reason>` - Temporarily warns a player for the duration and reason you specify
-* `/history [player] <page>` - View moderation actions taken against a player 
+Note: Command arguments in square brackets are \[required.] Command arguments in left/right arrows are \<optional>.
+
+* `/ban <-s> [PLAYER] <REASON | @LAYOUT>` - permanently bans a player for the reason you specify
+* `/tempban <-s> [PLAYER] [Xmo|Xd|Xh|Xm|Xs|#TIMELAYOUT] <REASON | @LAYOUT>` - Temporarily bans a player for the duration and reason you specify
+* `/kick <-s> [PLAYER] <REASON | @LAYOUT>` - Kicks a player you specify
+* `/mute <-s> [PLAYER] <REASON | @LAYOUT>` - permanently mutes a player for the reason you specify
+* `/tempmute <-s> [PLAYER] [Xmo|Xd|Xh|Xm|Xs|#TIMELAYOUT] <REASON | @LAYOUT>` - Temporarily mutes a player for the duration and reason you specify
+* `/warn <-s> [PLAYER] <REASON | @LAYOUT>` - Temporarily bans a player for the duration and reason you specify
+* `/tempwarn  <-s> [PLAYER] [Xmo|Xd|Xh|Xm|Xs|#TIMELAYOUT] <REASON | @LAYOUT>` - Temporarily warns a player for the duration and reason you specify
+* `/history [PLAYER] <PAGE>` - View moderation actions taken against a player 
 
 You can add -s to most of the punishment commands to make their outputs silent - this makes it so that people won't see an announcement when someone gets punished.
 

--- a/docs/plugins/AdvancedBan.md
+++ b/docs/plugins/AdvancedBan.md
@@ -34,7 +34,7 @@ If you decide to use MySQL for AdvancedBan, you can [learn how to setup a MySQL 
 ## Usage 
 AdvancedBan has many commands to be able to moderate and punish rule-breakers, the most important commands are here:
 
-Note: Command arguments in square brackets are \[required.] Command arguments in left/right arrows are \<optional>.
+Note: Command arguments in square brackets are required. Command arguments in left/right arrows are optional.
 
 * `/ban <-s> [PLAYER] <REASON | @LAYOUT>` - permanently bans a player for the reason you specify
 * `/tempban <-s> [PLAYER] [Xmo|Xd|Xh|Xm|Xs|#TIMELAYOUT] <REASON | @LAYOUT>` - Temporarily bans a player for the duration and reason you specify

--- a/docs/plugins/GriefPrevention.md
+++ b/docs/plugins/GriefPrevention.md
@@ -1,0 +1,62 @@
+---
+id: griefprevention
+title: GriefPrevention
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: GriefPrevention
+description: A simple and easy to use land claiming / protection plugin for your players.
+keywords:
+  - Spigot
+  - Region Management
+  - Land claiming
+  - GriefPrevention
+  - Pterodactyl Panel
+  - Minecraft
+  - Bloom.host
+image: https://bloom.host/assets/images/logo.png
+---
+
+# GriefPrevention
+
+## What does the plugin do?
+
+GriefPrevention is a land claiming / region plugin that is simple and easy to use for your players. Claiming land using this plugin is simple, even for people unfamiliar to commands as claiming land requires two right-clicks from the claim tool (default golden shovel).
+
+GriefPrevention can also prevent spam in multiple ways (fast message spam, join/leave spam, advertising, death spam, etc.)
+Most features can be turned on or off through the config.
+
+## Installation
+
+To install this plugin, download the server jar from its [Spigot resource page](https://www.spigotmc.org/resources/griefprevention.1884/) and install it into the `plugins` folder.
+For assistance on how to install plugins, please refer to the [plugin installation page](https://docs.bloom.host/plugins).
+
+## Usage
+
+GriefPrevention will work out of the box for most users. By default, your players will be able to claim land up to a 'claim allowance' which will prevent new players from claiming very large amounts of land that they might not use (making others unable to use that area.). There are commands which can be used to give allowance (for example, as a voting reward) to players.
+
+Claiming land is very simple. A player will need a golden shovel (changable in the config) and all they need to do is right click the two corners that they want to claim as long as it does not overlap other claims and they have enough claim allowance.
+
+There are a few basic commands that players will need to know. These are:
+
+* `/trust` - Used to allow another player to build in the claim the player is standing in. Useful if the player wants to grant building permissions to a friend.
+* `/containertrust` - Similar to `/trust` however it will only allow the player access to blocks with inventories such as chests.
+* `/accesstrust` - Similar to `/trust` however it will only allow the player access to iron doors (wooden doors and fence gates are not locked by default but this can be changed in the config) and buttons. 
+* `/permissiontrust` - Allows a player to share their trust level with other people. For example if someone gave `/accesstrust` to another player and `/permissiontrust`, that player would only be able to give `/accesstrust` to other people.
+* `/untrust` - Revokes a player's permission to access a claim given out using the trust commands above.
+* `/abandonclaim` - Deletes a claim that the player owns.
+* `/trustlist` - See a list of `/trust`ed players for that claim. See the trust commands above.
+* `/claimslist` - See the current claim allowance and all of a player's claims that they own.
+
+There is obviously more commands and features - please refer to the [GriefPrevention Wiki](https://github.com/TechFortress/GriefPrevention/wiki) for more infomation on how to use them.
+
+## Info
+
+[Spigot Resource Page](https://www.spigotmc.org/resources/griefprevention.1884/)
+
+[Website](https://griefprevention.com/)
+
+[Github](https://github.com/TechFortress/GriefPrevention)
+
+[Support](https://discord.com/invite/3TXnkfa)
+
+

--- a/docs/plugins/Milk.md
+++ b/docs/plugins/Milk.md
@@ -19,7 +19,7 @@ image: https://bloom.host/assets/images/logo.png
 
 ## What does the plugin do?
 
-Milk causes milk buckets to restore hunger and saturation upon consumption.
+The Milk plugin causes milk buckets to restore hunger and saturation upon consumption.
 
 ## Usage
 First, download the [Milk](https://www.spigotmc.org/resources/milk.84531/) plugin and install it into your `plugins` folder.   
@@ -27,7 +27,7 @@ First, download the [Milk](https://www.spigotmc.org/resources/milk.84531/) plugi
 Next start your server! Milk has been successfully installed.
 
 ## Commands
-Litebans offers two commands to customize the plugin
+The Milk plugin offers two commands to customize the plugin
 ```
 /setmilkfood
 /setmilksaturation

--- a/docs/plugins/luckperms.md
+++ b/docs/plugins/luckperms.md
@@ -30,6 +30,10 @@ Upload the jar into your `plugins` folder. Turn on or restart the server. If you
 
 To begin, simply run `/lp editor`. Once you have made your edits in the GUI, click save and run the command it gives you. If you need more help, consult the [LuckPerms wiki](https://luckperms.net/wiki/Home).  
 
+## Migration from other plugins
+
+You can migrate your permissions setup from various other permissions plugins (including PermissionsEx) and it is, in most cases a simple process. For more information on how to do this, refer to the [LuckPerms wiki](https://luckperms.net/wiki/Migration)
+
 ## Info
 
 [Website](https://luckperms.net/)  

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,6 +37,7 @@ module.exports = {
       {
         'Plugins': [
           'plugins/advancedanticheat',
+          'plugins/AdvancedBan',
           'plugins/bungeeguard', 
           'plugins/chunky', 
           'plugins/citizens2',
@@ -46,6 +47,7 @@ module.exports = {
           'plugins/discordsrv', 
           'plugins/dynmap', 
           'plugins/geysermc', 
+          'plugins/GriefPrevention',
           'plugins/Litebans', 
           'plugins/luckperms', 
           'plugins/Milk', 

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,7 @@ module.exports = {
       {
         'Plugins': [
           'plugins/advancedanticheat',
-          'plugins/AdvancedBan',
+          'plugins/advancedban',
           'plugins/bungeeguard', 
           'plugins/chunky', 
           'plugins/citizens2',
@@ -47,7 +47,7 @@ module.exports = {
           'plugins/discordsrv', 
           'plugins/dynmap', 
           'plugins/geysermc', 
-          'plugins/GriefPrevention',
+          'plugins/griefprevention',
           'plugins/Litebans', 
           'plugins/luckperms', 
           'plugins/Milk', 


### PR DESCRIPTION
This PR adds the following:

- A small section to the LuckPerms page about migration from other permission plugins
- Two new plugin pages (AdvancedBan - free LiteBans alternative & GriefPrevention - simple and easy to use land claiming plugin)
- Fix to the Milk plugin page where LiteBans is mentioned in the plugin description and the installation instructions.
- Add AdvancedBan MySQL config example to the databases page (so people know how to configure MySQL for AdvancedBan)